### PR TITLE
fix: no function id in module raydium_cp_swap::create_pool_fee_reveiver

### DIFF
--- a/cpmm-cpi/programs/cpmm-cpi/src/instructions/proxy_initialize.rs
+++ b/cpmm-cpi/programs/cpmm-cpi/src/instructions/proxy_initialize.rs
@@ -118,7 +118,7 @@ pub struct ProxyInitialize<'info> {
     /// create pool fee account
     #[account(
         mut,
-        address= raydium_cp_swap::create_pool_fee_reveiver::id(),
+        address= raydium_cp_swap::create_pool_fee_reveiver::ID,
     )]
     pub create_pool_fee: Box<InterfaceAccount<'info, TokenAccount>>,
 


### PR DESCRIPTION
>error[E0425]: cannot find function id in module raydium_cp_swap::create_pool_fee_reveiver --> 142 | address= raydium_cp_swap::create_pool_fee_reveiver::id(), | ^^ --> src/lib.rs:40:5


`raydium_cp_swap` crate doesn’t export an id() there (latest version expose only a constant), so we use the ID constant instead!